### PR TITLE
Fix stroke width in print PDF export

### DIFF
--- a/src/components/PatternExport/ExportPatternForPrintV3.tsx
+++ b/src/components/PatternExport/ExportPatternForPrintV3.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import jsPDF from 'jspdf';
 import { generatePbImage } from '@/functions/utilities/generate-pb-image';
-import { scaleSVG } from './scaling-SVG';
 import { buildLegend } from './render-legend';
 import { renderInstructions } from './render-instructions';
 import { DecorativeTitle, SectionLabel } from '@/components/ViewHelpers';
@@ -118,10 +117,7 @@ function slugify(s: string) {
 }
 
 async function svgToPng(svgStr: string, wPx: number, hPx: number): Promise<string> {
-  const src = svgStr.includes('xmlns=')
-    ? svgStr
-    : svgStr.replace('<svg', '<svg xmlns="http://www.w3.org/2000/svg"');
-  const blob = new Blob([src], { type: 'image/svg+xml;charset=utf-8' });
+  const blob = new Blob([svgStr], { type: 'image/svg+xml;charset=utf-8' });
   const url = URL.createObjectURL(blob);
   return new Promise((resolve, reject) => {
     const img = new Image();
@@ -139,6 +135,59 @@ async function svgToPng(svgStr: string, wPx: number, hPx: number): Promise<strin
     };
     img.src = url;
   });
+}
+
+// Prepare an SVG string for print rasterization at `targetWPx × targetHPx`.
+//
+// WHY this exists (not scaleSVG):
+//   scaleSVG sets stroke-width via setAttribute(), which is a CSS "presentation
+//   attribute". SVGs exported from Affinity Designer, Inkscape, etc. store
+//   stroke widths inside inline style="" or <style> blocks, which have higher
+//   CSS specificity and silently override the attribute. The result is that the
+//   original thin stroke from the file wins.
+//
+//   Fix: use regex to replace ALL stroke-width occurrences (both CSS and
+//   attribute) with the correct user-unit value derived from the viewBox.
+//   Formula: strokeUserUnits = lineWidthIn × (viewBoxWidth / patternWIn)
+//   This is unit-system-agnostic — works for mm, pt, px, or any other
+//   coordinate space the SVG uses.
+function prepareSvgForPrint(
+  svgString: string,
+  targetWPx: number,
+  targetHPx: number,
+  patternWIn: number,
+  lineWidthIn: number,
+): string {
+  let result = svgString;
+
+  // Ensure SVG namespace for canvas rendering
+  if (!result.includes('xmlns=')) {
+    result = result.replace('<svg', '<svg xmlns="http://www.w3.org/2000/svg"');
+  }
+
+  // Compute stroke width in SVG user units from the viewBox coordinate system
+  const vbMatch = result.match(/viewBox=["']\s*[\d.-]+\s+[\d.-]+\s+([\d.]+)\s+[\d.]+/i);
+  if (vbMatch) {
+    const viewBoxWidth = parseFloat(vbMatch[1]);
+    if (viewBoxWidth > 0 && patternWIn > 0) {
+      const userUnitsPerInch = viewBoxWidth / patternWIn;
+      const strokeUserUnits = (lineWidthIn * userUnitsPerInch).toFixed(5);
+      // Replace inline CSS  (style="...stroke-width:X...")
+      result = result.replace(/stroke-width\s*:\s*[\d.]+/g, `stroke-width:${strokeUserUnits}`);
+      // Replace presentation attribute  (stroke-width="X")
+      result = result.replace(/stroke-width=["'][\d.]+["']/g, `stroke-width="${strokeUserUnits}"`);
+    }
+  }
+
+  // Set the output pixel dimensions on the root <svg> element
+  result = result.replace(/(<svg\b[^>]*?)\s+width=["'][^"']*["']/i, `$1 width="${targetWPx}"`);
+  result = result.replace(/(<svg\b[^>]*?)\s+height=["'][^"']*["']/i, `$1 height="${targetHPx}"`);
+  // Inject width/height if the element had neither
+  if (!/\bwidth=["']\d/.test(result)) {
+    result = result.replace(/(<svg\b[^>]*)>/i, `$1 width="${targetWPx}" height="${targetHPx}">`);
+  }
+
+  return result;
 }
 
 function drawCropMarks(pdf: jsPDF, x: number, y: number, w: number, h: number) {
@@ -186,17 +235,10 @@ async function buildSinglePdf(a: SinglePdfArgs): Promise<void> {
   const availW = fw - 2 * M;
 
   // Rasterize pattern at exact requested size
-  const scaledSvg = scaleSVG({
-    svgText: a.svgString,
-    targetWidthPx: Math.round(a.patternWIn * DPI_SINGLE),
-    targetHeightPx: Math.round(a.patternHIn * DPI_SINGLE),
-    strokeWidthPx: Math.max(a.lineWidthIn * DPI_SINGLE, 0.5),
-  });
-  const patPng = await svgToPng(
-    scaledSvg,
-    Math.round(a.patternWIn * DPI_SINGLE),
-    Math.round(a.patternHIn * DPI_SINGLE),
-  );
+  const wPx = Math.round(a.patternWIn * DPI_SINGLE);
+  const hPx = Math.round(a.patternHIn * DPI_SINGLE);
+  const preparedSvg = prepareSvgForPrint(a.svgString, wPx, hPx, a.patternWIn, a.lineWidthIn);
+  const patPng = await svgToPng(preparedSvg, wPx, hPx);
 
   // Center pattern horizontally on the page
   const patX = M + (availW - a.patternWIn) / 2;
@@ -244,13 +286,8 @@ async function buildTiledPdf(a: TiledPdfArgs): Promise<void> {
   // the correct region falls within the printable area (jsPDF clips to page).
   const fullWPx = Math.round(a.patternWIn * DPI_TILED);
   const fullHPx = Math.round(a.patternHIn * DPI_TILED);
-  const scaledSvg = scaleSVG({
-    svgText: a.svgString,
-    targetWidthPx: fullWPx,
-    targetHeightPx: fullHPx,
-    strokeWidthPx: Math.max(a.lineWidthIn * DPI_TILED, 0.5),
-  });
-  const fullPng = await svgToPng(scaledSvg, fullWPx, fullHPx);
+  const preparedSvg = prepareSvgForPrint(a.svgString, fullWPx, fullHPx, a.patternWIn, a.lineWidthIn);
+  const fullPng = await svgToPng(preparedSvg, fullWPx, fullHPx);
 
   // Rasterize legend once; reuse across all pages
   const legendPng = await svgToPng(


### PR DESCRIPTION
scaleSVG sets stroke-width via DOM setAttribute(), which is a CSS presentation attribute. SVGs from Affinity Designer, Inkscape, etc. store stroke widths in inline style blocks or style="" which have higher CSS specificity — silently ignoring the setAttribute call and leaving the original thin strokes.

Replace scaleSVG with prepareSvgForPrint(), which uses regex to replace ALL stroke-width occurrences (both CSS and attribute forms). The correct user-unit value is derived from the SVG viewBox:

  strokeUserUnits = lineWidthIn × (viewBoxWidth / patternWIn)

This formula is coordinate-system-agnostic (mm, pt, px — doesn't matter) and always produces the exact physical stroke width from the database line_width field.