### PR TITLE
Add ExportPatternForSVG component with original and custom-size modes

### DIFF
--- a/src/components/PatternExport/ExportPatternForSVG.tsx
+++ b/src/components/PatternExport/ExportPatternForSVG.tsx
@@ -1,0 +1,393 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { generatePbImage } from '@/functions/utilities/generate-pb-image';
+import { buildLegend } from './render-legend';
+import { DecorativeTitle, SectionLabel } from '@/components/ViewHelpers';
+import { BorderedCard } from '@/components/cards/BorderedCard';
+import type { TypeViewData } from '@/functions/types/types';
+
+import { alpha } from '@mui/material/styles';
+import AspectRatioIcon from '@mui/icons-material/AspectRatio';
+import CropFreeIcon from '@mui/icons-material/CropFree';
+import DownloadIcon from '@mui/icons-material/Download';
+import LockIcon from '@mui/icons-material/Lock';
+
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Collapse,
+  Divider,
+  MenuItem,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const LEGEND_W_IN = 2.5;
+const LEGEND_SVG_PX = 320;
+const LEGEND_GAP_IN = 0.2;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type SvgExportMode = 'original' | 'custom';
+type PrintUnit = 'in' | 'cm' | 'mm';
+
+// ─── Unit helpers ─────────────────────────────────────────────────────────────
+
+function toIn(val: number, unit: PrintUnit): number {
+  if (unit === 'cm') return val / 2.54;
+  if (unit === 'mm') return val / 25.4;
+  return val;
+}
+
+function fromIn(valIn: number, unit: PrintUnit): number {
+  if (unit === 'cm') return valIn * 2.54;
+  if (unit === 'mm') return valIn * 25.4;
+  return valIn;
+}
+
+function dbToIn(value: number, unitStr: string): number {
+  const u = unitStr.toLowerCase().trim();
+  if (u.startsWith('in')) return value;
+  if (u === 'cm') return value / 2.54;
+  if (u === 'mm') return value / 25.4;
+  if (u === 'px') return value / 96;
+  return value;
+}
+
+function r2(n: number): number { return Math.round(n * 100) / 100; }
+function r3(n: number): number { return Math.round(n * 1000) / 1000; }
+
+function slugify(s: string): string {
+  return s.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+}
+
+// ─── Legend geometry — mirrors render-legend.ts height formula exactly ────────
+
+function legendPhysicalHeightIn(keyCount: number): number {
+  const PAD = 20, HEADER_H = 32, SUB_H = 22, STAT_H = 20, STATS = 4, DIV_H = 16, KEY_H = 32;
+  const px = PAD + HEADER_H + SUB_H + 6 + STATS * STAT_H + DIV_H + keyCount * KEY_H + PAD;
+  return px * (LEGEND_W_IN / LEGEND_SVG_PX);
+}
+
+// ─── SVG helpers ──────────────────────────────────────────────────────────────
+
+interface SvgViewBox { vbX: number; vbY: number; vbW: number; vbH: number; }
+
+function parseSvgViewBox(svgStr: string): SvgViewBox | null {
+  const m = svgStr.match(/viewBox=["']\s*([\d.-]+)\s+([\d.-]+)\s+([\d.]+)\s+([\d.]+)/i);
+  if (!m) return null;
+  return { vbX: parseFloat(m[1]), vbY: parseFloat(m[2]), vbW: parseFloat(m[3]), vbH: parseFloat(m[4]) };
+}
+
+// Strips the outer <svg ...> and </svg> wrapper, leaving inner content only.
+function extractSvgInner(svgStr: string): string {
+  return svgStr
+    .replace(/<svg\b[^>]*>/i, '')
+    .replace(/<\/svg>\s*$/i, '');
+}
+
+// Replaces all stroke-width values (CSS and attribute forms) with the correct
+// user-unit value for the target physical size. Same formula as prepareSvgForPrint
+// in the print component — works regardless of SVG coordinate system units.
+function normalizeSvgStrokes(svgString: string, patternWIn: number, lineWidthIn: number): string {
+  const m = svgString.match(/viewBox=["']\s*[\d.-]+\s+[\d.-]+\s+([\d.]+)\s+[\d.]+/i);
+  if (!m) return svgString;
+  const viewBoxWidth = parseFloat(m[1]);
+  if (viewBoxWidth <= 0 || patternWIn <= 0) return svgString;
+  const userUnitsPerInch = viewBoxWidth / patternWIn;
+  const strokeUU = (lineWidthIn * userUnitsPerInch).toFixed(5);
+  return svgString
+    .replace(/stroke-width\s*:\s*[\d.]+/g, `stroke-width:${strokeUU}`)
+    .replace(/stroke-width=["'][\d.]+["']/g, `stroke-width="${strokeUU}"`);
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export const ExportPatternForSVG = ({ viewData }: TypeViewData) => {
+  const queryClient = useQueryClient();
+
+  const baseWIn = viewData ? dbToIn(viewData.design_width, viewData.design_width_unit) : 1;
+  const baseHIn = viewData ? dbToIn(viewData.design_height, viewData.design_height_unit) : 1;
+  const aspectRatio = baseWIn > 0 && baseHIn > 0 ? baseHIn / baseWIn : 1;
+  const lineWidthIn = viewData ? Math.max(dbToIn(viewData.line_width, viewData.line_width_unit), 0.005) : 0.039;
+
+  const [mode, setMode] = useState<SvgExportMode>('original');
+  const [unit, setUnit] = useState<PrintUnit>('in');
+  const [patternWidthInput, setPatternWidthInput] = useState(() => String(r3(baseWIn)));
+  const [patternHeightInput, setPatternHeightInput] = useState(() => String(r3(baseHIn)));
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [svgString, setSvgString] = useState('');
+
+  // Fetch SVG source
+  useEffect(() => {
+    if (!viewData?.pattern_file) return;
+    fetch(generatePbImage(viewData))
+      .then((r) => r.text())
+      .then(setSvgString)
+      .catch(console.error);
+  }, [viewData?.id]);
+
+  // Sync inputs when viewData changes
+  useEffect(() => {
+    if (viewData) {
+      setPatternWidthInput(String(r3(fromIn(baseWIn, unit))));
+      setPatternHeightInput(String(r3(fromIn(baseHIn, unit))));
+    }
+  }, [viewData?.id]);
+
+  const handleUnitChange = (newUnit: PrintUnit) => {
+    const w = parseFloat(patternWidthInput);
+    const h = parseFloat(patternHeightInput);
+    if (!isNaN(w) && w > 0) setPatternWidthInput(String(r3(fromIn(toIn(w, unit), newUnit))));
+    if (!isNaN(h) && h > 0) setPatternHeightInput(String(r3(fromIn(toIn(h, unit), newUnit))));
+    setUnit(newUnit);
+  };
+
+  // Bidirectional ratio-locked handlers — each updates only the OTHER field
+  const handleWidthChange = (raw: string) => {
+    setPatternWidthInput(raw);
+    const n = parseFloat(raw);
+    if (!isNaN(n) && n > 0) {
+      setPatternHeightInput(String(r3(fromIn(toIn(n, unit) * aspectRatio, unit))));
+    }
+  };
+
+  const handleHeightChange = (raw: string) => {
+    setPatternHeightInput(raw);
+    const n = parseFloat(raw);
+    if (!isNaN(n) && n > 0) {
+      setPatternWidthInput(String(r3(fromIn(toIn(n, unit) / aspectRatio, unit))));
+    }
+  };
+
+  // Derived dimensions — original mode always uses DB values
+  const patternWIn = (() => {
+    if (mode === 'original') return baseWIn;
+    const n = parseFloat(patternWidthInput);
+    return !isNaN(n) && n > 0 ? toIn(n, unit) : 0;
+  })();
+  const patternHIn = patternWIn * aspectRatio;
+
+  const keyCount = viewData?.pattern_key_reference_list?.length ?? 0;
+  const legendHIn = legendPhysicalHeightIn(keyCount);
+
+  const canExport = !!svgString && patternWIn > 0;
+
+  const handleExport = useCallback(async () => {
+    if (!canExport || !viewData) return;
+    setError(null);
+    setLoading(true);
+
+    try {
+      const authorLine =
+        viewData.expand?.authors?.map((a) => a.name).join(', ') ||
+        viewData.author_manual?.join(', ') ||
+        '';
+      const projectSizeLabel = `${r2(patternWIn)}in × ${r2(patternHIn)}in`;
+      const lineWidthLabel = `${viewData.line_width}${viewData.line_width_unit}`;
+
+      const legendOutput = await buildLegend({
+        patternName: viewData.name,
+        authorLine,
+        projectSizeLabel,
+        pieces: viewData.pieces,
+        lineWidthLabel,
+        designDate: viewData.design_date as Date | null,
+        keys: viewData.pattern_key_reference_list ?? [],
+        queryClient,
+      });
+
+      const resolvedLegendHIn = legendOutput.height * (LEGEND_W_IN / LEGEND_SVG_PX);
+
+      const vb = parseSvgViewBox(svgString);
+      if (!vb) throw new Error('Pattern SVG is missing a viewBox — cannot composite.');
+
+      // Convert legend physical dimensions into pattern SVG user-unit space
+      const userUnitsPerInch = vb.vbW / patternWIn;
+      const gapUU = LEGEND_GAP_IN * userUnitsPerInch;
+      const legendWUU = LEGEND_W_IN * userUnitsPerInch;
+      const legendHUU = resolvedLegendHIn * userUnitsPerInch;
+      const totalVbH = vb.vbH + gapUU + legendHUU;
+      const totalHIn = patternHIn + LEGEND_GAP_IN + resolvedLegendHIn;
+
+      // Custom mode: normalize stroke widths to the target physical size
+      let processedSvg = svgString;
+      if (mode === 'custom') {
+        processedSvg = normalizeSvgStrokes(svgString, patternWIn, lineWidthIn);
+      }
+
+      // Ensure SVG namespace so the composite is well-formed
+      if (!processedSvg.includes('xmlns=')) {
+        processedSvg = processedSvg.replace('<svg', '<svg xmlns="http://www.w3.org/2000/svg"');
+      }
+
+      const patternInner = extractSvgInner(processedSvg);
+
+      // Namespace the legend's filter ID to prevent collisions in the composite document
+      const safeLegendSvg = legendOutput.svg
+        .replace(/id="shadow"/g, 'id="legend-card-shadow"')
+        .replace(/url\(#shadow\)/g, 'url(#legend-card-shadow)');
+      const legendInner = extractSvgInner(safeLegendSvg);
+
+      // Build composite: pattern content + legend as a nested <svg> in user-unit space
+      const composite = [
+        `<svg xmlns="http://www.w3.org/2000/svg"`,
+        ` viewBox="${vb.vbX} ${vb.vbY} ${vb.vbW} ${totalVbH}"`,
+        ` width="${r3(patternWIn)}in"`,
+        ` height="${r3(totalHIn)}in"`,
+        `>`,
+        patternInner,
+        `<svg`,
+        ` x="${vb.vbX}" y="${vb.vbY + vb.vbH + gapUU}"`,
+        ` width="${legendWUU}" height="${legendHUU}"`,
+        ` viewBox="0 0 ${LEGEND_SVG_PX} ${legendOutput.height}"`,
+        `>`,
+        legendInner,
+        `</svg>`,
+        `</svg>`,
+      ].join('');
+
+      const blob = new Blob([composite], { type: 'image/svg+xml;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${slugify(viewData.name)}${mode === 'custom' ? `-${r2(patternWIn)}in` : ''}.svg`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Export failed. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [canExport, viewData, svgString, mode, patternWIn, patternHIn, lineWidthIn, legendHIn, queryClient]);
+
+  return (
+    <BorderedCard>
+      <DecorativeTitle>Export SVG</DecorativeTitle>
+
+      {/* Export type */}
+      <Box sx={{ mb: 2.5 }}>
+        <SectionLabel>Export Type</SectionLabel>
+
+        <ToggleButtonGroup
+          value={mode}
+          exclusive
+          size="small"
+          onChange={(_, v) => v && setMode(v as SvgExportMode)}
+          sx={toggleGroupSx}
+        >
+          <ToggleButton value="original">
+            <CropFreeIcon fontSize="small" />
+            Original Size
+          </ToggleButton>
+          <ToggleButton value="custom">
+            <AspectRatioIcon fontSize="small" />
+            Custom Size
+          </ToggleButton>
+        </ToggleButtonGroup>
+
+        <Typography variant="caption" sx={{ color: 'text.secondary', display: 'block', mt: 0.75 }}>
+          {mode === 'original'
+            ? `Downloads at the original designed size (${r2(baseWIn)}" × ${r2(baseHIn)}") with the legend embedded.`
+            : 'Scale to any size while keeping line thickness consistent.'}
+        </Typography>
+      </Box>
+
+      {/* Custom size inputs */}
+      <Collapse in={mode === 'custom'}>
+        <Divider sx={{ borderColor: alpha('#C8A96E', 0.12), mb: 2.5 }} />
+
+        <Box sx={{ mb: 2.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 1 }}>
+            <SectionLabel>Pattern Size</SectionLabel>
+            <Tooltip title="Editing either dimension updates the other to preserve the aspect ratio." arrow>
+              <LockIcon sx={{ fontSize: '0.8rem', color: 'text.secondary', mb: '2px', cursor: 'help' }} />
+            </Tooltip>
+          </Box>
+
+          <Box sx={{ display: 'grid', gridTemplateColumns: '1fr 1fr 80px', gap: 1.5, alignItems: 'flex-start' }}>
+            <TextField
+              label={`Width (${unit})`}
+              size="small"
+              variant="filled"
+              fullWidth
+              value={patternWidthInput}
+              onChange={(e) => handleWidthChange(e.target.value)}
+            />
+            <TextField
+              label={`Height (${unit})`}
+              size="small"
+              variant="filled"
+              fullWidth
+              value={patternHeightInput}
+              onChange={(e) => handleHeightChange(e.target.value)}
+            />
+            <TextField
+              select
+              size="small"
+              variant="filled"
+              label="Unit"
+              value={unit}
+              onChange={(e) => handleUnitChange(e.target.value as PrintUnit)}
+            >
+              {(['in', 'cm', 'mm'] as PrintUnit[]).map((u) => (
+                <MenuItem key={u} value={u}>
+                  {u}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Box>
+        </Box>
+      </Collapse>
+
+      <Divider sx={{ borderColor: alpha('#C8A96E', 0.12), mb: 2 }} />
+
+      <Collapse in={!!error}>
+        <Alert severity="error" sx={{ mb: 1.5, fontSize: '0.82rem' }}>
+          {error}
+        </Alert>
+      </Collapse>
+
+      <Button
+        variant="contained"
+        fullWidth
+        disabled={!canExport || loading}
+        startIcon={loading ? <CircularProgress size={16} color="inherit" /> : <DownloadIcon />}
+        onClick={handleExport}
+        sx={{ fontWeight: 700, letterSpacing: '0.06em', py: 1.1, textTransform: 'none' }}
+      >
+        {loading ? 'Generating SVG…' : 'Download SVG'}
+      </Button>
+    </BorderedCard>
+  );
+};
+
+// ─── Shared styles ────────────────────────────────────────────────────────────
+
+const toggleGroupSx = {
+  '& .MuiToggleButton-root': {
+    borderColor: alpha('#C8A96E', 0.3),
+    color: 'text.secondary',
+    px: 2,
+    gap: 0.75,
+    fontSize: '0.8rem',
+    textTransform: 'none' as const,
+    '&.Mui-selected': {
+      bgcolor: alpha('#C8A96E', 0.15),
+      color: 'primary.main',
+      borderColor: alpha('#C8A96E', 0.5),
+      '&:hover': { bgcolor: alpha('#C8A96E', 0.2) },
+    },
+    '&:hover': { bgcolor: alpha('#C8A96E', 0.07) },
+  },
+};

--- a/src/components/ViewDrawer.tsx
+++ b/src/components/ViewDrawer.tsx
@@ -5,6 +5,7 @@ import { ExportPatternForPrintV2 } from '@/components/ExportPatternForPrintV2';
 import { ExportPatternForPrintV3 } from '@/components/PatternExport/ExportPatternForPrintV3';
 import { ExportPatternToDownloadV2 } from '@/components/ExportPatternToDownloadV2';
 import { ExportPatternToDownloadV3 } from '@/components/PatternExport/ExportPatternToDownloadV3';
+import { ExportPatternForSVG } from '@/components/PatternExport/ExportPatternForSVG';
 import type { TypeExportPatternContext } from '@/components/PatternExport/useExportPattern';
 import { createPrettyDate } from '@/functions/utilities/dates';
 import { generatePbImage } from '@/functions/utilities/generate-pb-image';
@@ -113,6 +114,10 @@ export const ViewDrawer = (props: ViewDrawerProps) => {
 
             {!viewData?.pattern_file_external && (
               <ExportPatternForPrintV3 viewData={viewData} key={'print' + viewData?.id} />
+            )}
+
+            {!viewData?.pattern_file_external && (
+              <ExportPatternForSVG viewData={viewData} key={'svg' + viewData?.id} />
             )}
 
             {!viewData?.pattern_file_external && (


### PR DESCRIPTION
Adds a new SVG export card to the ViewDrawer with two modes:
- Original Size: composites the pattern SVG with an embedded legend card at the DB-specified physical dimensions, no stroke changes.
- Custom Size: ratio-locked bidirectional width/height inputs (same UX as the print card) with stroke width normalized using the same viewBox-based formula as ExportPatternForPrintV3 so line thickness is physically correct at any size.

Both modes build a composite SVG by embedding pattern inner content directly alongside the legend as a nested <svg> positioned in the pattern's user-unit coordinate space. Legend filter IDs are namespaced to avoid collisions. Output SVG carries width/height in inches so vector apps open at correct scale.